### PR TITLE
Change name of groups zabbix-agent and zadbbix-servers 

### DIFF
--- a/etc/inv/inventory_default
+++ b/etc/inv/inventory_default
@@ -38,7 +38,7 @@ backend
 [mysql]
 10.218.0.117
 
-[zabbix-agent]
+[zabbix_agent]
 3.8.158.189
 
 [naszaaplikacja]

--- a/etc/inv/inventory_default_zabbix
+++ b/etc/inv/inventory_default_zabbix
@@ -5,10 +5,10 @@ system_env=szkolenie
 zabbix-servers
 zabbix-agents
 
-[zabbix-servers]
+[zabbix_servers]
 1.2.3.4
 
-[zabbix-agents]
+[zabbix_agents]
 3.8.158.189
 52.56.161.127
 52.56.177.236 #nowy serwer

--- a/playbooks/install_zabbix_example.yml
+++ b/playbooks/install_zabbix_example.yml
@@ -2,7 +2,7 @@
 #Uruchomienie:
 #~/szkolenie3$ ansible-playbook playbooks/install_zabbix_example.yml 
 
-- hosts: zabbix-agents
+- hosts: zabbix_agents
   become: true
 
   vars:


### PR DESCRIPTION
to use _ (dash) instead of - (minus).
Ansible currently need to use dash in group names, instead of -.
https://github.com/ansible/ansible/issues/30624